### PR TITLE
fix: Update manifest for compatibility

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,8 @@
   "content_scripts": [
     {
       "matches": ["https://garticphone.com/*"],
-      "js": ["contentScript.bundle.js"]
+      "js": ["contentScript.bundle.js"],
+      "all_frames": true
     }
   ],
   "web_accessible_resources": [


### PR DESCRIPTION
Update manifest so extension runs in gartic phone instances running inside iframes, which resolves compatibility issues with https://github.com/HonzaKubita/garticTools